### PR TITLE
__str__ for gvars with nan mean or sdev doesn't crash

### DIFF
--- a/src/gvar/_gvarcore.pyx
+++ b/src/gvar/_gvarcore.pyx
@@ -97,7 +97,12 @@ cdef class GVar:
         v = self.mean
 
         # special cases
-        if dv == float('inf'):
+        if numpy.isnan(v) or numpy.isnan(dv):
+            if numpy.isnan(v) != numpy.isnan(dv):
+                return '%g +- %g'%(v, dv) # mean or error is not nan
+            else:
+                return 'nan(nan)' # mean and error are nan
+        elif dv == float('inf'):
             return '%g +- inf' % v
         elif v == 0 and (dv >= 1e5 or dv < 1e-4):
             if dv == 0:


### PR DESCRIPTION
Currently, GVar will raise an exception when attempting to print (or otherwise render to string) a GVar with a nan for either its mean or sdev.  For example, any of
`>>> print gv.gvar(float('nan'), float('nan'))`
`>>> print gv.gvar(1, float('nan'))`
`>>> print gv.gvar(float('nan'), 1)`
will raise exceptions.

The issue is in the helper function `GVar.__str__.ndec`, specifically line 92:
`ans = int(ans)`
which raises an exception when ans is nan.

This change defines behavior for when the mean and/or sdev are nan, such that
```
>>> print gv.gvar(float('nan'), float('nan'))
nan(nan)
>>> print gv.gvar(1, float('nan'))
1 +- nan
>>> print gv.gvar(float('nan'), 1)
nan +- 1
```

Versus simply printing 'nan', this output format makes it easy to differentiate between a simple float nan or a GVar nan.  It can be diagnostically useful to know if one of the mean or sdev are not nan, hence the 'nan +- 1' and '1 +- nan' output formats.

All GVar tests run by 'make tests' pass.  All non-GSL lsqfit tests run by 'make tests' also pass.