### PR TITLE
Fix ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long' on win-amd64

### DIFF
--- a/src/gvar/_utilities.pyx
+++ b/src/gvar/_utilities.pyx
@@ -554,7 +554,7 @@ def evalcov_blocks(g, compress=False):
         if len(bl) == 1:
             b = bl.pop()
             gb = gf[b]
-            ans.append((numpy.array([b]), numpy.array([[gb.var]])))
+            ans.append((numpy.array([b], dtype=numpy.intp), numpy.array([[gb.var]])))
         else:
             idx = numpy.array([b for b in bl], dtype=numpy.intp)
             ans.append((idx, evalcov(gf[idx])))


### PR DESCRIPTION
```
> py -3.8 empbayes.py
*** empbayes_fit warning: null logGBF
Traceback (most recent call last):
  File "empbayes.py", line 36, in <module>
    fit,z = lsqfit.empbayes_fit(1.0, fitargs)
  File "X:\Python38\lib\site-packages\lsqfit\_extras.py", line 169, in empbayes_fit
    return lsqfit.nonlinear_fit(**args), z
  File "X:\Python38\lib\site-packages\lsqfit\__init__.py", line 562, in __init__
    x, y, prior, fdata = _unpack_data(
  File "X:\Python38\lib\site-packages\lsqfit\__init__.py", line 1718, in _unpack_data
    yp, fdata = _apply_svd(numpy.concatenate((y.flat, prior.flat)))
  File "X:\Python38\lib\site-packages\lsqfit\__init__.py", line 1671, in _apply_svd
    ans, inv_wgts = _gvar.svd(
  File "X:\Python38\lib\site-packages\gvar\__init__.py", line 603, in svd
    idx_bcov = evalcov_blocks(g.flat, compress=True)
  File "src\gvar\_utilities.pyx", line 563, in gvar._utilities.evalcov_blocks
ValueError: Buffer dtype mismatch, expected 'npy_intp' but got 'long'
```