### PR TITLE
Specify index type for more efficient access

### DIFF
--- a/src/gvar/_utilities.pyx
+++ b/src/gvar/_utilities.pyx
@@ -496,7 +496,7 @@ def evalcov_blocks(g, compress=False):
             uncorrelated |GVar|\s in ``g.flat`` into the first element of 
             the returned list (see above). Default is ``False``.
     """
-    cdef INTP_TYPE a, b
+    cdef INTP_TYPE a, b, i
     cdef GVar ga, gb
     cdef smat master_cov
     # cdef numpy.ndarray[numpy.npy_intp, ndim=1] idx, ga_d_indices


### PR DESCRIPTION
Fix Cython warning: `_utilities.pyx:536:51: Index should be typed for more efficient access`